### PR TITLE
implemented Node:insertBefore

### DIFF
--- a/gumbo/dom/Document.lua
+++ b/gumbo/dom/Document.lua
@@ -28,15 +28,18 @@ Document.__newindex = util.newindexFactory(Document)
 
 function Document:createElement(localName)
     assert(localName:find(namePattern), "InvalidCharacterError")
-    return setmetatable({localName = localName:lower()}, Element)
+    return setmetatable({
+        localName = localName:lower(),
+        ownerDocument = self
+    }, Element)
 end
 
 function Document:createTextNode(data)
-    return setmetatable({data = data}, Text)
+    return setmetatable({data = data, ownerDocument = self}, Text)
 end
 
 function Document:createComment(data)
-    return setmetatable({data = data}, Comment)
+    return setmetatable({data = data, ownerDocument = self}, Comment)
 end
 
 -- https://dom.spec.whatwg.org/#concept-node-adopt

--- a/gumbo/dom/Node.lua
+++ b/gumbo/dom/Node.lua
@@ -81,7 +81,6 @@ function Node:hasChildNodes()
     return self.childNodes[1] and true or false
 end
 
--- TODO: function Node:insertBefore(node, child)
 -- TODO: function Node:replaceChild(node, child)
 
 local isValidParentNode = Set {
@@ -219,6 +218,23 @@ function Node:appendChild(node)
     assert(type(node) == "table", "TypeError: Argument is not a Node")
     assert(node.childNodes, "TypeError: Argument is not a Node")
     return preInsert(node, self)
+end
+
+-- https://developer.mozilla.org/en-US/docs/Web/API/Node.insertBefore
+function Node:insertBefore(node, child)
+    assert(type(node) == "table",
+        "TypeError: Argument node is not a Node")
+    assert(node.childNodes, "TypeError: Argument node is not a Node")
+    -- "If referenceElement is null, or undefined, newElement is
+    -- inserted at the end of the list of child nodes"
+    -- (i.e. same as appendChild)
+    if nil ~= child then
+        assert(type(child) == "table",
+            "TypeError: Argument child is not a Node")
+        assert(child.childNodes,
+            "TypeError: Argument child is not a Node")
+    end
+    return preInsert(node, self, child)
 end
 
 function Node:removeChild(child)

--- a/runtests.lua
+++ b/runtests.lua
@@ -16,6 +16,7 @@ local tests = {
     "test/dom/Element-childElementCount.lua",
     "test/dom/Comment-constructor.lua",
     "test/dom/Node-appendChild.lua",
+    "test/dom/Node-insertBefore.lua",
     "test/misc.lua",
     "test/tostring.lua",
     "test/tree-construction.lua",

--- a/test/dom/Node-insertBefore.lua
+++ b/test/dom/Node-insertBefore.lua
@@ -1,0 +1,72 @@
+local gumbo = require "gumbo"
+local assert, pcall = assert, pcall
+local _ENV = nil
+
+local input = [[
+<header id=header></header>
+<div id="main" class="foo bar baz etc">
+    <h1 id="h1">Title <!--comment --></h1>
+</div>
+<footer id=footer>...</footer>
+]]
+
+local document = assert(gumbo.parse(input))
+local body = assert(document.body)
+local main = assert(document:getElementById("main"))
+local h1 = assert(document:getElementById("h1"))
+local header = assert(document:getElementById("header"))
+local footer = assert(document:getElementById("footer"))
+
+assert(body.childElementCount == 3)
+assert(body.children[1] == header)
+assert(body.children[2] == main)
+assert(body.children[3] == footer)
+
+assert(body:insertBefore(main, header) == main)
+assert(body.childElementCount == 3)
+assert(body.children[1] == main)
+assert(body.children[2] == header)
+assert(body.children[3] == footer)
+
+assert(body:insertBefore(header, header) == header)
+assert(body.childElementCount == 3)
+assert(body.children[1] == main)
+assert(body.children[2] == header)
+assert(body.children[3] == footer)
+
+assert(body:insertBefore(h1, main) == h1)
+assert(body.childElementCount == 4)
+assert(body.firstElementChild == h1)
+
+local p = assert(document:createElement("p"))
+assert(p.parentNode == nil)
+assert(body:insertBefore(p, h1) == p)
+assert(p.parentNode == body)
+assert(body.childElementCount == 5)
+assert(body.firstElementChild == p)
+
+assert(footer.childNodes.length == 1)
+assert(main.parentNode == body)
+assert(footer:insertBefore(main, footer.childNodes[1]) == main)
+assert(main.parentNode == footer)
+assert(body.childElementCount == 4)
+assert(footer.childNodes.length == 2)
+assert(footer.firstElementChild == main)
+assert(body.children[3] == header)
+assert(body.children[4] == footer)
+
+local append = assert(document:createElement("a"))
+assert(body:insertBefore(append) == append)
+assert(body.childElementCount == 5)
+assert(body.children[5] == append)
+
+-- TODO: Add test coverage for every assertion in ensurePreInsertionValidity()
+assert(not pcall(header.insertBefore, main, footer.childNodes[1]))
+assert(not pcall(body.insertBefore, body, 9))
+assert(not pcall(body.insertBefore, body, "string"))
+assert(not pcall(body.insertBefore, body, true))
+assert(not pcall(body.insertBefore, body, false))
+assert(not pcall(body.insertBefore, body, nil))
+assert(not pcall(body.insertBefore, body, body))
+assert(not pcall(body.insertBefore, body, document))
+assert(not pcall(main.insertBefore, main, body))


### PR DESCRIPTION
Read CONTRIBUTING.md, fiddled about with git (usually I use http://fossil-scm.org), rebased into single commit.
Note that setting `ownerDocument = self` in `Document:create...` is vital for appendChild to work properly, too. But I did not want to split out that minor tweak to a separate branch.
